### PR TITLE
Fix overwrite bugs in admin

### DIFF
--- a/pages/Livesite/schedule.js
+++ b/pages/Livesite/schedule.js
@@ -80,7 +80,6 @@ export default function Events({ hackathons }) {
     newEvent.lastModifiedBy = user;
     newEvent.startTime = new Date(newEvent.startTime).toISOString();
     newEvent.endTime = new Date(newEvent.endTime).toISOString();
-    newEvent.type = 'main';
     const eventID = await addLivesiteEvent(activeHackathon, { ...newEvent });
     newEvent.lastModified = formatDate(getTimestamp().seconds);
     setEvents({

--- a/pages/Livesite/schedule.js
+++ b/pages/Livesite/schedule.js
@@ -80,6 +80,7 @@ export default function Events({ hackathons }) {
     newEvent.lastModifiedBy = user;
     newEvent.startTime = new Date(newEvent.startTime).toISOString();
     newEvent.endTime = new Date(newEvent.endTime).toISOString();
+    newEvent.category = newEvent.category ?? 'main';
     const eventID = await addLivesiteEvent(activeHackathon, { ...newEvent });
     newEvent.lastModified = formatDate(getTimestamp().seconds);
     setEvents({
@@ -97,7 +98,6 @@ export default function Events({ hackathons }) {
     eventEditing.lastModified = user;
     eventEditing.startTime = new Date(eventEditing.startTime).toISOString();
     eventEditing.endTime = new Date(eventEditing.endTime).toISOString();
-    eventEditing.category = eventEditing.category ?? 'main';
     await updateLivesiteEvent(activeHackathon, { ...eventEditing });
     eventEditing.lastModified = formatDate(getTimestamp().seconds);
     setEvents({

--- a/pages/Livesite/schedule.js
+++ b/pages/Livesite/schedule.js
@@ -97,6 +97,7 @@ export default function Events({ hackathons }) {
     eventEditing.lastModified = user;
     eventEditing.startTime = new Date(eventEditing.startTime).toISOString();
     eventEditing.endTime = new Date(eventEditing.endTime).toISOString();
+    eventEditing.category = eventEditing.category ?? 'main';
     await updateLivesiteEvent(activeHackathon, { ...eventEditing });
     eventEditing.lastModified = formatDate(getTimestamp().seconds);
     setEvents({

--- a/pages/Livesite/schedule.js
+++ b/pages/Livesite/schedule.js
@@ -80,7 +80,7 @@ export default function Events({ hackathons }) {
     newEvent.lastModifiedBy = user;
     newEvent.startTime = new Date(newEvent.startTime).toISOString();
     newEvent.endTime = new Date(newEvent.endTime).toISOString();
-    newEvent.category = newEvent.category ?? 'main';
+    newEvent.type = newEvent.type ?? 'main';
     const eventID = await addLivesiteEvent(activeHackathon, { ...newEvent });
     newEvent.lastModified = formatDate(getTimestamp().seconds);
     setEvents({

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -336,8 +336,13 @@ export default function Faq({ hackathons }) {
               <ModalField
                 label="Category"
                 modalAction={NEW}
-                onChange={(category) => {
-                  handleInput('category', category.label, newFaq, setNewFaq);
+                onChange={(event) => {
+                  handleInput(
+                    'category',
+                    event.target.value,
+                    newFaq,
+                    setNewFaq
+                  );
                 }}
                 value={FAQCategory.GENERAL}
               />

--- a/pages/faq.js
+++ b/pages/faq.js
@@ -132,7 +132,7 @@ export default function Faq({ hackathons }) {
   }, [alertMsg]);
 
   const handleNew = async () => {
-    newFaq.category = newFaq.category ? newFaq.category : FAQCategory.GENERAL;
+    newFaq.category = newFaq.category ?? FAQCategory.GENERAL;
     newFaq.lastModifiedBy = user;
     const faqID = await addFaq(newFaq);
     newFaq.lastModified = formatDate(getTimestamp().seconds);


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
Closes #140.

Event types were hardcoded to `main` (changed in #62), so I just removed that line. @ianmah do you remember why this was required as a hotfix? Just wanna make sure I'm not breaking anything else.

FAQ was bugged because the `onChange` handler was written to expect a label event instead of a text input field event. Just changed it to `event.target.value` and it looks like it's working well.