### PR TITLE
Update rubric

### DIFF
--- a/components/Evaluator/HackerList.js
+++ b/components/Evaluator/HackerList.js
@@ -84,7 +84,7 @@ export default function HackerList({
             score={applicant.score}
             selectHacker={() => setSelectedApplicant(applicant)}
             hasCompleted={
-              applicant.score && Object.keys(applicant.score.scores).length >= 4
+              applicant.score && Object.keys(applicant.score.scores).length >= 3
             }
             isSelected={
               selectedApplicant && selectedApplicant._id === applicant._id

--- a/components/Evaluator/RubricDropdown.js
+++ b/components/Evaluator/RubricDropdown.js
@@ -60,9 +60,9 @@ const StyledOption = styled.div`
 `;
 
 const rubricOptions = [
-  { value: 'DEV', label: 'Developer' },
-  { value: 'DESIGN', label: 'Design' },
-  { value: 'GENERAL', label: 'General' },
+  { value: 'DEV', label: 'Resume - Developer' },
+  { value: 'DESIGN', label: 'Resume - Design' },
+  { value: 'GENERAL', label: 'Resume - First Time Hacker' },
   { value: 'LONG_ANSWER', label: 'Long answer' },
 ];
 

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -54,9 +54,6 @@ export default function Scoring({ shouldDisplay, applicant }) {
     // Switch to whatever the field is in Firebase
     let field = '';
     switch (label) {
-      case SCORING.LINK.label:
-        field = 'LinkScore';
-        break;
       case SCORING.RESUME.label:
         field = 'ResumeScore';
         break;
@@ -83,12 +80,6 @@ export default function Scoring({ shouldDisplay, applicant }) {
     <Container shouldDisplay={shouldDisplay}>
       <Title4 color={COLOR.MIDNIGHT_PURPLE}>Scoring</Title4>
       <ScoreInputs>
-        <ScoreInput
-          label={SCORING.LINK.label}
-          handleClick={handleClick}
-          score={scores?.LinkScore}
-          maxScore={SCORING.LINK}
-        />
         <ScoreInput
           label={SCORING.RESUME.label}
           handleClick={handleClick}

--- a/constants.js
+++ b/constants.js
@@ -129,11 +129,6 @@ export const APPLICATION_STATUS = {
 };
 
 export const SCORING = {
-  LINK: {
-    label: 'GitHub/Personal Website',
-    value: 7,
-    weight: 1,
-  },
   RESUME: {
     label: 'Resume',
     value: 7,


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
Turns out that the Resume and GitHub/Personal Website scores are the same thing, so those are combined now. If there were users that were graded _before_ this change, we need to manually go into Firestore and remove the `LinkScore` score on their record.

The rubric is also more clear now as to which hacker type it applies to (dev, design, or first time).
