### PR TITLE
Fix modal overflow

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -137,11 +137,13 @@ const ModalBackground = styled.div`
   /* TODO: add media queries to make width responsive */
   width: 740px;
   max-width: 100%;
-  max-height: 100%;
+  max-height: 70%;
+  overflow: scroll;
 `;
 
 const ButtonContainer = styled.div`
   margin: 0;
+  padding-bottom: 20px;
   float: right;
   display: inline-block;
 `;

--- a/components/modal.js
+++ b/components/modal.js
@@ -138,7 +138,7 @@ const ModalBackground = styled.div`
   width: 740px;
   max-width: 100%;
   max-height: 70%;
-  overflow: scroll;
+  overflow-y: auto;
 `;
 
 const ButtonContainer = styled.div`


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/7uWf15xyHwU3S/giphy.gif)

## Description
Closes #138. Set max-height to 75% and added overflow support to fix the bug.

Also just added some padding to the button container since it was hugging the bottom edge before.

Before (unscrollable):
![image](https://user-images.githubusercontent.com/5078356/147395906-02ab64e3-144f-468c-bd57-85dc7c504420.png)

After:
![image](https://user-images.githubusercontent.com/5078356/147395904-c4071451-b3c9-44c9-955d-1fdfd95c5c08.png)
