### PR TITLE
Remove link for assessment and update rubric

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -226,18 +226,6 @@ export default ({ hackathons, currentPath }) => {
           );
         })}
 
-        <NextLink href="/assessment" as="/assessment" passHref>
-          <Link>
-            <ItemContainer>
-              <Icon
-                color={currentPath === 'assessment' && COLOR.WHITE}
-                icon="user-check"
-              />
-              <Label selected={currentPath === 'assessment'}>Assessment</Label>
-            </ItemContainer>
-          </Link>
-        </NextLink>
-
         <NextLink href="/eval" as="/eval" passHref>
           <Link>
             <ItemContainer>

--- a/constants.js
+++ b/constants.js
@@ -239,10 +239,10 @@ export const RUBRIC = {
     },
     {
       score: '+1',
-      label: 'For each extracurricular activity (1 point each, max 3 points)',
+      label: 'For each extracurricular activity (1 point each, max 2 points)',
     },
     {
-      score: '+2',
+      score: '+1',
       label: 'If extracurricular activities are tech-related',
     },
     {


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/COYGe9rZvfiaQ/giphy.gif)

## Description
Removes the link in sidebar for assessment so that people don't access the old assessment tool. I've kept the page and files live for now since we may need to refer to them for functionality like exporting CSVs, downloading resumes, etc.

Additionally there's some updates to the rubric, so I threw them in here as well