### PR TITLE
Scoring bug fix again

### DIFF
--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -42,14 +42,14 @@ const SmallText = styled.div`
 `;
 
 export default function Scoring({ shouldDisplay, applicant }) {
-  const [scores, setScores] = useState(null);
+  const [scores, setScores] = useState({});
   const [totalScore, setTotalScore] = useState(null);
   const [comment, setComment] = useState('');
 
   const { user } = useContext(AuthContext);
 
   useEffect(() => {
-    setScores(applicant?.score?.scores || null);
+    setScores(applicant?.score?.scores || {});
     setTotalScore(applicant?.score?.totalScore || null);
     setComment(applicant?.score?.comment || '');
   }, [applicant]);


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
I did an oopsie and forgot to handle this in #176. I was setting the `score` object as `null` and eval was breaking because of that :^)
