### PR TITLE
Emergency PR for scoring

### DIFF
--- a/components/Evaluator/HackerList.js
+++ b/components/Evaluator/HackerList.js
@@ -158,7 +158,9 @@ export default function HackerList({
             score={applicant.score}
             selectHacker={() => setSelectedApplicant(applicant)}
             hasCompleted={
-              applicant.score && Object.keys(applicant.score.scores).length >= 3
+              applicant.score &&
+              applicant.score.scores &&
+              Object.keys(applicant.score.scores).length >= 3
             }
             isSelected={
               selectedApplicant && selectedApplicant._id === applicant._id

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -52,7 +52,7 @@ export default function Scoring({ shouldDisplay, applicant }) {
     setScores(applicant?.score?.scores || {});
     setTotalScore(applicant?.score?.totalScore || null);
     setComment(applicant?.score?.comment || '');
-  }, [applicant]);
+  }, [applicant?._id]);
 
   const handleClick = (score, label) => {
     // Switch to whatever the field is in Firebase


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
Okay so apparently my fix from #177 might not be a fix, so just prepping this PR for immediate merge if it happens again :^) (which it shouldn't because I'm a great programmer and would never write bad code)

Also the entire applicant list updates whenever somebody writes to the collection, which causes the Scoring component to rerender (removing all your current progress). By changing the `useEffect` to depend on the `id` of the applicant changing, it will only rerender when you yourself change selected applicant.