### PR TITLE
Enable Portal specific FAQs

### DIFF
--- a/pages/faq.js
+++ b/pages/faq.js
@@ -550,6 +550,7 @@ export default function Faq({ hackathons }) {
 
 export const getStaticProps = async () => {
   const hackathons = await getHackathons();
+  hackathons.push('Portal'); // Enable Portal specific FAQs
   return {
     props: {
       hackathons,


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
We want to have the ability to specify FAQs for Portal and nothing else. This seems to be a quick and dirty way of doing it without having to change a lot of other stuff.
