### PR TITLE
fixed team member display, currently read-only field

### DIFF
--- a/components/Judging/TeamMembersSelector.js
+++ b/components/Judging/TeamMembersSelector.js
@@ -1,0 +1,145 @@
+// teamMembers should be array of object:
+//
+// [
+//     {
+//         discord,
+//         email,
+//         id,
+//         name
+//     },
+//     ...
+// ]
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+const TeamMembersSelector = (props) => {
+  const { value, updateValue } = props;
+  // onChange => ('teamMembers', e)
+
+  const copyValues = () => {
+    const duplicate = [];
+    value.forEach((item) => {
+      duplicate.push(item);
+    });
+    return duplicate;
+  };
+
+  const [members, setMembers] = useState(value);
+  const [renderMembers, setRenderMembers] = useState([]);
+  const [trigger, setTrigger] = useState(false);
+  const [isAdding, setIsAdding] = useState(false);
+
+  const InputArea = styled.div`
+    background: white;
+    padding: 0.5rem;
+    border: 1px solid #eeeeee;
+    display: flex;
+    gap: 0.5rem;
+    position: relative;
+    min-height: calc(1rem + calc(1rem * 1.2));
+  `;
+
+  const Member = styled.div`
+    background: #2d2937;
+    color: white;
+    padding: 0.5rem 0.7rem;
+    border-radius: 5px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  `;
+
+  const AddText = styled.span`
+    margin: 0.5rem 0.3rem;
+    cursor: pointer;
+    font-weight: 600;
+    position: absolute;
+    top: 0.5rem;
+    right: 10px;
+  `;
+
+  const AddPanel = styled.div`
+    transition: all 0.2s linear;
+    background: white;
+    padding: 0.5rem;
+    border-style: none solid solid solid;
+    border-width: 1px;
+    border-color: #EEEEEE;
+  `;
+
+  const handleAddMember = () => {};
+
+  const handleDeleteMember = (index) => {
+    const currentMembers = members;
+    currentMembers.splice(index, 1);
+    setMembers(currentMembers);
+    setTrigger(!trigger);
+  };
+
+  const DeleteIcon = ({ index }) => {
+    return (
+      <div
+        style={{
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        role="button"
+        tabIndex="0"
+        onKeyPress={() => handleDeleteMember(index)}
+        onClick={() => handleDeleteMember(index)}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </div>
+    );
+  };
+
+  useEffect(() => {
+    const renderArray = [];
+
+    members.forEach((item, index) => {
+      renderArray.push(
+        <Member key={index}>
+          {item.name}
+          {/* <DeleteIcon index={index} /> */}
+        </Member>
+      );
+    });
+
+    setRenderMembers(renderArray);
+  }, [trigger]);
+
+  return (
+    <>
+      <InputArea>
+        {renderMembers}
+        {/* <AddText onClick={() => setIsAdding(!isAdding)}>
+          {isAdding ? 'Cancel' : 'Add Member'}
+        </AddText> */}
+      </InputArea>
+      <AddPanel
+        style={{
+          display: isAdding ? 'flex' : 'none',
+        }}
+      >
+        yuh
+      </AddPanel>
+    </>
+  );
+};
+
+export default TeamMembersSelector;

--- a/components/projectsCard.js
+++ b/components/projectsCard.js
@@ -79,7 +79,11 @@ export default ({
                     Link
                   </a>
                 </Text>
-                <Text>{project.teamMembers?.toString()}</Text>
+                <Text>
+                  {project.teamMembers.map((item, index) => (
+                    <span key={index}>{item.name} </span>
+                  ))}
+                </Text>
                 <Actions>
                   <Button
                     type={EDIT}

--- a/pages/Livesite/judging.js
+++ b/pages/Livesite/judging.js
@@ -14,6 +14,7 @@ import {
 } from '../../utility/firebase';
 import { EDIT, NEW, LIVESITE_NAVBAR } from '../../constants';
 import ProjectsCard from '../../components/projectsCard';
+import TeamMembersSelector from '../../components/Judging/TeamMembersSelector';
 
 const Label = styled.p`
   font-weight: bold;
@@ -67,8 +68,8 @@ export default ({ hackathons }) => {
 
   const formatProject = (project) => {
     project.sponsorPrizes = stringToArr(project.sponsorPrizes);
-    project.teamMembers = stringToArr(project.teamMembers);
     project.teamMembersEmails = stringToArr(project.teamMembersEmails);
+    // project.teamMembers = stringToArr(project.teamMembers);
     return project;
   };
 
@@ -108,7 +109,8 @@ export default ({ hackathons }) => {
     setData({
       ...projects[key],
       id: key,
-      teamMembers: projects[key].teamMembers?.toString(),
+      // teamMembers: projects[key].teamMembers?.toString(),
+      teamMembers: projects[key].teamMembers,
       teamMembersEmails: projects[key].teamMembersEmails?.toString(),
       sponsorPrizes: projects[key].sponsorPrizes?.toString(),
     });
@@ -163,10 +165,10 @@ export default ({ hackathons }) => {
           value={data.youtubeUrl}
           onChange={(e) => handleChange('youtubeUrl', e)}
         />
-        <Label>Team Members (Comma separated)</Label>
-        <Input
+        <Label>Team Members</Label>
+        <TeamMembersSelector
           value={data.teamMembers}
-          onChange={(e) => handleChange('teamMembers', e)}
+          updateValue={handleChange}
         />
         <Label>Team Emails (Comma separated)</Label>
         <Input


### PR DESCRIPTION


## Description
<!--- Describe your changes! Include screenshots/video if applicable -->
"Team Members" field on `Livesite > Judging > Project Edit` would display `[Object object]` instead of relevant information

Now, the field shows the names of the team members
![image](https://user-images.githubusercontent.com/26179641/156737263-42357716-b977-457c-9222-ec0855cb7d08.png)

### * important note *

Read-only right now, but will add "Add Member" and "Remove Member" features soon...
