### PR TITLE
status changer

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -219,6 +219,15 @@ export default ({ hackathons, currentPath }) => {
           </Link>
         </NextLink>
 
+        <NextLink href="/status" as="/status" passHref>
+          <Link>
+            <ItemContainer>
+              <Icon color={currentPath === 'status' && COLOR.WHITE} icon="clipboard" />
+              <Label selected={currentPath === 'status'}>Status Changer</Label>
+            </ItemContainer>
+          </Link>
+        </NextLink>
+
         <Link
           href="#!"
           onClick={() => {

--- a/pages/status.js
+++ b/pages/status.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import Page from '../components/page'
 import { getHackathons, getApplicants, updateApplicantStatus } from '../utility/firebase'
 import Button from '../components/button'
+import Checkbox from '../components/checkbox'
 
 const Container = styled.div`
   display: flex;
@@ -26,6 +27,12 @@ const Text = styled.div`
   font-size: 24px;
 `
 
+const FormatOptions = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+`
+
 const ApplicantsInput = styled.textarea`
   resize: vertical;
 `
@@ -47,6 +54,7 @@ const hackerStatuses = [
 ]
 
 export default function Status({ hackathons }) {
+  const [emailFormat, setEmailFormat] = useState('\n')
   const [emails, setEmails] = useState('')
   const [hackathonSelected, setHackathonSelected] = useState('')
   const [statusSelected, setStatusSelected] = useState('')
@@ -74,7 +82,7 @@ export default function Status({ hackathons }) {
     setError('')
     if (!validateInputs()) return
 
-    let emailList = emails.split(',')
+    let emailList = emails.split(emailFormat)
     emailList = emailList.map(email => email.trim())
 
     const applicants = await getApplicants(hackathonSelected)
@@ -112,7 +120,11 @@ export default function Status({ hackathons }) {
       <Container>
         {success && <Success>{success}</Success>}
         {error && <Error>{error}</Error>}
-        <Text>Enter emails, separated by a comma:</Text>
+        <Text>Enter emails:</Text>
+        <FormatOptions>
+          <Checkbox label="Separated by newline" checked={emailFormat === '\n'} onClick={() => setEmailFormat('\n')} />
+          <Checkbox label="Separated by comma" checked={emailFormat === ','} onClick={() => setEmailFormat(',')} />
+        </FormatOptions>
         <ApplicantsInput
           placeholder="e.g. alvin.kam.33@gmail.com,heyitsme@hotmail.com..."
           value={emails}

--- a/pages/status.js
+++ b/pages/status.js
@@ -46,10 +46,9 @@ const hackerStatuses = [
   'applied',
   'waitlisted',
   'rejected',
-  'acceptedNoResponseYet',
+  'accepted',
   'acceptedAndAttending',
   'acceptedUnRSVP',
-  'acceptedNoRSVP',
   'inProgress',
 ]
 

--- a/pages/status.js
+++ b/pages/status.js
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import Page from '../components/page'
+import { getHackathons, getApplicants, updateApplicantStatus } from '../utility/firebase'
+import Button from '../components/button'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: left;
+  gap: 16px;
+`
+
+const Success = styled.div`
+  background: #00b775;
+  padding: 16px;
+`
+
+const Error = styled.div`
+  background: #eb5757;
+  white-space: pre-wrap;
+  padding: 16px;
+`
+
+const Text = styled.div`
+  font-size: 24px;
+`
+
+const ApplicantsInput = styled.textarea`
+  resize: vertical;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  margin-top: 8px;
+`
+
+const hackerStatuses = [
+  'applied',
+  'waitlisted',
+  'rejected',
+  'acceptedNoResponseYet',
+  'acceptedAndAttending',
+  'acceptedUnRSVP',
+  'acceptedNoRSVP',
+  'inProgress',
+]
+
+export default function Status({ hackathons }) {
+  const [emails, setEmails] = useState('')
+  const [hackathonSelected, setHackathonSelected] = useState('')
+  const [statusSelected, setStatusSelected] = useState('')
+  const [success, setSuccess] = useState('')
+  const [error, setError] = useState('')
+
+  const validateInputs = () => {
+    if (!emails) {
+      setError('Please enter one or more emails')
+      return false
+    }
+    if (!hackathonSelected) {
+      setError('Please select a hackathon')
+      return false
+    }
+    if (!statusSelected) {
+      setError('Please select a status')
+      return false
+    }
+    return true
+  }
+
+  const handleUpdate = async () => {
+    setSuccess('')
+    setError('')
+    if (!validateInputs()) return
+
+    let emailList = emails.split(',')
+    emailList = emailList.map(email => email.trim())
+
+    const applicants = await getApplicants(hackathonSelected)
+    const filteredApplicants = []
+    const filteredEmails = new Set()
+    const unfoundApplicants = []
+
+    for (const applicant of applicants) {
+      if (emailList.includes(applicant.basicInfo?.email)) {
+        filteredApplicants.push(applicant._id)
+        filteredEmails.add(applicant.basicInfo?.email)
+      }
+    }
+
+    for (const email of emailList) {
+      if (!filteredEmails.has(email)) {
+        unfoundApplicants.push(email)
+      }
+    }
+
+    for (const userId of filteredApplicants) {
+      await updateApplicantStatus(userId, statusSelected, hackathonSelected)
+    }
+
+    if (filteredApplicants.length > 0) {
+      setSuccess(`Updated ${filteredApplicants.length} hacker(s) to ${statusSelected} status`)
+    }
+    if (unfoundApplicants.length > 0) {
+      setError(`Could not find ${unfoundApplicants.length} email(s) in list provided:\n${unfoundApplicants.join('\n')}`)
+    }
+  }
+
+  return (
+    <Page currentPath="status" hackathons={hackathons}>
+      <Container>
+        {success && <Success>{success}</Success>}
+        {error && <Error>{error}</Error>}
+        <Text>Enter emails, separated by a comma:</Text>
+        <ApplicantsInput
+          placeholder="e.g. alvin.kam.33@gmail.com,heyitsme@hotmail.com..."
+          value={emails}
+          onChange={e => setEmails(e.target.value)}
+        />
+        <Text>Choose a hackathon:</Text>
+        <select value={hackathonSelected} onChange={e => setHackathonSelected(e.target.value)}>
+          <option value="" disabled selected hidden>
+            Hackathon...
+          </option>
+          {hackathons.map(hackathon => (
+            <option value={hackathon} key={hackathon}>
+              {hackathon}
+            </option>
+          ))}
+        </select>
+        <Text>Choose a status:</Text>
+        <select value={statusSelected} onChange={e => setStatusSelected(e.target.value)}>
+          <option value="" disabled selected hidden>
+            Status...
+          </option>
+          {hackerStatuses.map(status => (
+            <option value={status} key={status}>
+              {status}
+            </option>
+          ))}
+        </select>
+        <ButtonContainer>
+          <Button hoverBackgroundColor="#EB5757" onClick={handleUpdate}>
+            Update
+          </Button>
+        </ButtonContainer>
+      </Container>
+    </Page>
+  )
+}
+
+export const getStaticProps = async () => {
+  const hackathons = await getHackathons()
+  return {
+    props: {
+      hackathons,
+    },
+  }
+}

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -522,6 +522,10 @@ export const getHackerInfo = async (callback, hackathon, collection) => {
   return res
 }
 
+export const getApplicants = async hackathon => {
+  const data = await db.collection('Hackathons').doc(hackathon).collection('Applicants').get()
+  return data.docs.map(doc => doc.data())
+}
 // Asessment portal
 export const getAllApplicants = async callback => {
   return db
@@ -673,10 +677,15 @@ export const updateApplicantScore = async (applicantID, scores, comment, adminEm
     })
 }
 
-export const updateApplicantStatus = async (userId, applicationStatus) => {
-  return db.collection('Hackathons').doc(HackerEvaluationHackathon).collection('Applicants').doc(userId).update({
-    'status.applicationStatus': applicationStatus,
-  })
+export const updateApplicantStatus = async (userId, applicationStatus, hackathon) => {
+  return db
+    .collection('Hackathons')
+    .doc(hackathon || HackerEvaluationHackathon)
+    .collection('Applicants')
+    .doc(userId)
+    .update({
+      'status.applicationStatus': applicationStatus,
+    })
 }
 
 export const getApplicantTags = async (userId, callback) => {


### PR DESCRIPTION
- only changes status, does not change booleans such as responded/attended
- added error validation to make sure all inputs are filled/selected
- email input is separated by newline or comma and also trims whitespace to avoid weird issues - if the format we receive is different this is pretty easy to change
- the email input does not validate email format but filters against all applicants queried in the DB
- success/error messages will indicate how many emails in the parsed input were successfully found and which ones weren't, but DOES NOT indicate whether api calls have failed
