### PR TITLE
Connect hacker app form to firebase

### DIFF
--- a/components/page.js
+++ b/components/page.js
@@ -5,8 +5,6 @@ import { COLOR } from '../constants'
 import Navbar from './navbar'
 import Sidebar from './sidebar'
 import HackerAppNavbar from './hackerAppNavbar'
-import Button from './button'
-import Icon from './Icon'
 
 const HeaderContainer = styled.div`
   display: flex;

--- a/components/page.js
+++ b/components/page.js
@@ -43,12 +43,6 @@ const StyledHackerAppSection = styled.div`
   gap: 75px;
 `
 
-const StyledButton = styled(Button)`
-  display: flex;
-  align-items: center;
-  gap: 10px;
-`
-
 const StyledHackerAppNav = styled.div`
   display: flex;
   align-items: center;
@@ -84,14 +78,6 @@ export default ({
                   <Header>Hacker Application / {hackerAppHeader}</Header>
                   {loading && <LoadingImage src={LoadingGif} />}
                 </HeaderContainer>
-                <StyledButton
-                  color={COLOR.MIDNIGHT_PURPLE_DEEP}
-                  contentColor={COLOR.WHITE}
-                  hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
-                >
-                  <Icon color={COLOR.WHITE} icon="save" />
-                  Save
-                </StyledButton>
               </StyledHackerAppNav>
               <StyledHackerAppSection>
                 <HackerAppNavbar

--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -140,7 +140,7 @@ const QuestionCard = ({ question, removeQuestion, id, moveUp, moveDown, handleCh
       <TitleBar>
         <Bar style={{ width: '90%' }}>
           <Icon color={COLOR.MIDNIGHT_PURPLE_DEEP} icon="question-circle" />
-          <StyledField type="text" placeholder="Untitled" value={question.title} readOnly />
+          <StyledField type="text" placeholder="Untitled" value={question.title || ''} readOnly />
         </Bar>
         <Bar>
           <StyledQuestionButton onClick={() => setToggled(!isToggled)}>
@@ -166,17 +166,17 @@ const QuestionCard = ({ question, removeQuestion, id, moveUp, moveDown, handleCh
           <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Question</QuestionTitle>
           <TextField
             placeholder="Question title"
-            customValue={question.title}
+            customValue={question.title || ''}
             onChangeCustomValue={e => handleChange(id, 'title', e.target.value)}
           />
           <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Description (optional)</QuestionTitle>
           <TextField
             placeholder="Question description"
-            customValue={question.description}
+            customValue={question.description || ''}
             onChangeCustomValue={e => handleChange(id, 'description', e.target.value)}
           />
           <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Question Type</QuestionTitle>
-          <QuestionDropdown onSelect={o => handleChange(id, 'type', o)} defaultValue={question.type} />
+          <QuestionDropdown onSelect={o => handleChange(id, 'type', o)} defaultValue={question.type || ''} />
         </>
       )}
       {isToggled &&
@@ -186,7 +186,7 @@ const QuestionCard = ({ question, removeQuestion, id, moveUp, moveDown, handleCh
         <div>
           <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Options</QuestionTitle>
           <StyledOptions>
-            {question.options.map((option, index) => (
+            {(question.options || []).map((option, index) => (
               <OptionsContent key={index}>
                 <TextField
                   placeholder={`Option ${index + 1}`}
@@ -205,7 +205,7 @@ const QuestionCard = ({ question, removeQuestion, id, moveUp, moveDown, handleCh
           <StyledOtherToggle>
             <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Add Other</QuestionTitle>
             <StyledToggle
-              checked={question.other}
+              checked={question.other || false}
               icons={false}
               onChange={() => handleChange(id, 'other', !question.other)}
             />
@@ -215,7 +215,7 @@ const QuestionCard = ({ question, removeQuestion, id, moveUp, moveDown, handleCh
       {isToggled && (
         <StyledOtherToggle style={{ justifyContent: 'flex-end' }}>
           <StyledToggle
-            checked={question.required}
+            checked={question.required || false}
             icons={false}
             onChange={() => handleChange(id, 'required', !question.required)}
           />

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -150,8 +150,8 @@ export default ({ id, hackathons }) => {
           color={COLOR.MIDNIGHT_PURPLE_DEEP}
           contentColor={COLOR.WHITE}
           hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
-          onClick={() => {
-            handleSave(id)
+          onClick={async () => {
+            await handleSave(id)
           }}
         >
           <Icon color={COLOR.WHITE} icon="save" />

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -1,10 +1,16 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { getHackathonPaths, getHackathons } from '../../../utility/firebase'
+import {
+  getHackerAppQuestions,
+  getHackathonPaths,
+  getHackathons,
+  updateHackerAppQuestions,
+} from '../../../utility/firebase'
 import Page from '../../../components/page'
 import { HACKER_APP_NAVBAR, COLOR } from '../../../constants'
 import QuestionCard from '../../../components/questionCard'
 import Icon from '../../../components/Icon'
+import Button from '../../../components/button'
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -36,10 +42,30 @@ const QuestionsContainer = styled.div`
   gap: 10px;
 `
 
+const StyledButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: absolute;
+  top: 60px;
+  right: 80px;
+`
+
 export default ({ id, hackathons }) => {
   const [questions, setQuestions] = useState([
     { title: '', description: '', type: '', options: [''], other: false, required: false },
   ])
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      const questions = await getHackerAppQuestions(id, 'BasicInfo')
+      setQuestions(questions)
+    }
+    fetchQuestions()
+    return () => {
+      setQuestions([{ title: '', description: '', type: '', options: [''], other: false, required: false }])
+    }
+  }, [id])
 
   const addQuestion = index => {
     const newQuestions = [...questions]
@@ -88,6 +114,11 @@ export default ({ id, hackathons }) => {
     setQuestions(newQuestions)
   }
 
+  const handleSave = async hackathon => {
+    await updateHackerAppQuestions(hackathon, questions, 'BasicInfo')
+    alert('Questions were saved to the database!')
+  }
+
   return (
     <>
       <Page
@@ -96,6 +127,17 @@ export default ({ id, hackathons }) => {
         hackerAppHeader={id}
         hackerAppNavbarItems={HACKER_APP_NAVBAR}
       >
+        <StyledButton
+          color={COLOR.MIDNIGHT_PURPLE_DEEP}
+          contentColor={COLOR.WHITE}
+          hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
+          onClick={() => {
+            handleSave(id)
+          }}
+        >
+          <Icon color={COLOR.WHITE} icon="save" />
+          Save
+        </StyledButton>
         <HeaderContainer>
           <Header>2. Add basic information questions</Header>
         </HeaderContainer>

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -5,12 +5,17 @@ import {
   getHackathonPaths,
   getHackathons,
   updateHackerAppQuestions,
+  getHackerAppQuestionsMetadata,
+  formatDate,
+  getTimestamp,
+  updateHackerAppQuestionsMetadata,
 } from '../../../utility/firebase'
 import Page from '../../../components/page'
 import { HACKER_APP_NAVBAR, COLOR } from '../../../constants'
 import QuestionCard from '../../../components/questionCard'
 import Icon from '../../../components/Icon'
 import Button from '../../../components/button'
+import { useAuth } from '../../../utility/auth'
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -51,17 +56,31 @@ const StyledButton = styled(Button)`
   right: 80px;
 `
 
+const StyledMetadataP = styled.p`
+  position: absolute;
+  top: 100px;
+  right: 80px;
+  color: ${COLOR.MIDNIGHT_PURPLE};
+`
+
 export default ({ id, hackathons }) => {
   const [questions, setQuestions] = useState([
     { title: '', description: '', type: '', options: [''], other: false, required: false },
   ])
+  const [metadata, setMetadata] = useState({})
+  const { email: user } = useAuth().user
 
   useEffect(() => {
     const fetchQuestions = async () => {
       const appQuestions = await getHackerAppQuestions(id, 'BasicInfo')
       setQuestions(appQuestions)
     }
+    const fetchMetadata = async () => {
+      const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'BasicInfo')
+      setMetadata(fetchedMetadata)
+    }
     fetchQuestions()
+    fetchMetadata()
   }, [id])
 
   const addQuestion = index => {
@@ -113,6 +132,9 @@ export default ({ id, hackathons }) => {
 
   const handleSave = async hackathon => {
     await updateHackerAppQuestions(hackathon, questions, 'BasicInfo')
+    const newMetadata = { lastEditedAt: getTimestamp(), lastEditedBy: user }
+    setMetadata(newMetadata)
+    await updateHackerAppQuestionsMetadata(hackathon, 'BasicInfo', newMetadata)
     alert('Questions were saved to the database!')
   }
 
@@ -135,6 +157,9 @@ export default ({ id, hackathons }) => {
           <Icon color={COLOR.WHITE} icon="save" />
           Save
         </StyledButton>
+        <StyledMetadataP>{`Last Edited by ${metadata.lastEditedBy} at ${formatDate(
+          metadata.lastEditedAt?.seconds
+        )}`}</StyledMetadataP>
         <HeaderContainer>
           <Header>2. Add basic information questions</Header>
         </HeaderContainer>

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -62,9 +62,6 @@ export default ({ id, hackathons }) => {
       setQuestions(appQuestions)
     }
     fetchQuestions()
-    return () => {
-      setQuestions([])
-    }
   }, [id])
 
   const addQuestion = index => {

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -58,12 +58,12 @@ export default ({ id, hackathons }) => {
 
   useEffect(() => {
     const fetchQuestions = async () => {
-      const questions = await getHackerAppQuestions(id, 'BasicInfo')
-      setQuestions(questions)
+      const appQuestions = await getHackerAppQuestions(id, 'BasicInfo')
+      setQuestions(appQuestions)
     }
     fetchQuestions()
     return () => {
-      setQuestions([{ title: '', description: '', type: '', options: [''], other: false, required: false }])
+      setQuestions([])
     }
   }, [id])
 

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -129,7 +129,7 @@ export default ({ id, hackathons }) => {
           contentColor={COLOR.WHITE}
           hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
           onClick={() => {
-            handleSave(id, questions)
+            handleSave(id)
           }}
         >
           <Icon color={COLOR.WHITE} icon="save" />

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -58,12 +58,12 @@ export default ({ id, hackathons }) => {
 
   useEffect(() => {
     const fetchQuestions = async () => {
-      const questions = await getHackerAppQuestions(id, 'Skills')
-      setQuestions(questions)
+      const appQuestions = await getHackerAppQuestions(id, 'Skills')
+      setQuestions(appQuestions)
     }
     fetchQuestions()
     return () => {
-      setQuestions([{ title: '', description: '', type: '', options: [''], other: false, required: false }])
+      setQuestions([])
     }
   }, [id])
 
@@ -114,7 +114,7 @@ export default ({ id, hackathons }) => {
     setQuestions(newQuestions)
   }
 
-  const handleSave = async (hackathon, questions) => {
+  const handleSave = async hackathon => {
     await updateHackerAppQuestions(hackathon, questions, 'Skills')
     alert('Questions were saved to the database!')
   }

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -150,8 +150,8 @@ export default ({ id, hackathons }) => {
           color={COLOR.MIDNIGHT_PURPLE_DEEP}
           contentColor={COLOR.WHITE}
           hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
-          onClick={() => {
-            handleSave(id)
+          onClick={async () => {
+            await handleSave(id)
           }}
         >
           <Icon color={COLOR.WHITE} icon="save" />

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -1,10 +1,16 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { getHackathonPaths, getHackathons } from '../../../utility/firebase'
+import {
+  getHackathonPaths,
+  getHackathons,
+  getHackerAppQuestions,
+  updateHackerAppQuestions,
+} from '../../../utility/firebase'
 import Page from '../../../components/page'
 import { HACKER_APP_NAVBAR, COLOR } from '../../../constants'
 import QuestionCard from '../../../components/questionCard'
 import Icon from '../../../components/Icon'
+import Button from '../../../components/button'
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -36,10 +42,30 @@ const QuestionsContainer = styled.div`
   gap: 10px;
 `
 
+const StyledButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: absolute;
+  top: 60px;
+  right: 80px;
+`
+
 export default ({ id, hackathons }) => {
   const [questions, setQuestions] = useState([
     { title: '', description: '', type: '', options: [''], other: false, required: false },
   ])
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      const questions = await getHackerAppQuestions(id, 'Skills')
+      setQuestions(questions)
+    }
+    fetchQuestions()
+    return () => {
+      setQuestions([{ title: '', description: '', type: '', options: [''], other: false, required: false }])
+    }
+  }, [id])
 
   const addQuestion = index => {
     const newQuestions = [...questions]
@@ -88,6 +114,11 @@ export default ({ id, hackathons }) => {
     setQuestions(newQuestions)
   }
 
+  const handleSave = async (hackathon, questions) => {
+    await updateHackerAppQuestions(hackathon, questions, 'Skills')
+    alert('Questions were saved to the database!')
+  }
+
   return (
     <>
       <Page
@@ -96,6 +127,17 @@ export default ({ id, hackathons }) => {
         hackerAppHeader={id}
         hackerAppNavbarItems={HACKER_APP_NAVBAR}
       >
+        <StyledButton
+          color={COLOR.MIDNIGHT_PURPLE_DEEP}
+          contentColor={COLOR.WHITE}
+          hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
+          onClick={() => {
+            handleSave(id, questions)
+          }}
+        >
+          <Icon color={COLOR.WHITE} icon="save" />
+          Save
+        </StyledButton>
         <HeaderContainer>
           <Header>3. Add skills and long answer questions</Header>
         </HeaderContainer>

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -62,9 +62,6 @@ export default ({ id, hackathons }) => {
       setQuestions(appQuestions)
     }
     fetchQuestions()
-    return () => {
-      setQuestions([])
-    }
   }, [id])
 
   const addQuestion = index => {

--- a/pages/hackerapps/[id]/welcome.js
+++ b/pages/hackerapps/[id]/welcome.js
@@ -126,8 +126,8 @@ export default ({ id, hackathons }) => {
           color={COLOR.MIDNIGHT_PURPLE_DEEP}
           contentColor={COLOR.WHITE}
           hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
-          onClick={() => {
-            handleSave(id)
+          onClick={async () => {
+            await handleSave(id)
           }}
         >
           <Icon color={COLOR.WHITE} icon="save" />

--- a/pages/hackerapps/[id]/welcome.js
+++ b/pages/hackerapps/[id]/welcome.js
@@ -1,10 +1,17 @@
 import dynamic from 'next/dynamic'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import TextField from '../../../components/TextField'
 import Page from '../../../components/page'
 import { COLOR, HACKER_APP_NAVBAR } from '../../../constants'
-import { getHackathonPaths, getHackathons } from '../../../utility/firebase'
+import {
+  getHackathonPaths,
+  getHackathons,
+  updateHackerAppQuestions,
+  getHackerAppQuestions,
+} from '../../../utility/firebase'
+import Button from '../../../components/button'
+import Icon from '../../../components/Icon'
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false })
 
@@ -46,6 +53,15 @@ const Header = styled.h1`
   color: ${COLOR.MIDNIGHT_PURPLE_DEEP};
 `
 
+const StyledButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: absolute;
+  top: 60px;
+  right: 80px;
+`
+
 const descModules = {
   toolbar: [
     ['bold', 'italic', 'underline', 'strike', 'blockquote'],
@@ -59,6 +75,27 @@ const formats = ['bold', 'italic', 'underline', 'strike', 'blockquote', 'list', 
 
 export default ({ id, hackathons }) => {
   const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      const questions = await getHackerAppQuestions(id, 'Welcome')
+      setTitle(questions[0].title || '')
+      setContent(questions[0].content || '')
+    }
+    fetchQuestions()
+    return () => {
+      setTitle('')
+      setContent('')
+    }
+  }, [id])
+
+  const handleSave = async hackathon => {
+    const questions = [{ title: title, content: content }]
+    await updateHackerAppQuestions(hackathon, questions, 'Welcome')
+    alert('Questions were saved to the database!')
+  }
+
   return (
     <>
       <Page
@@ -67,6 +104,17 @@ export default ({ id, hackathons }) => {
         hackerAppHeader={id}
         hackerAppNavbarItems={HACKER_APP_NAVBAR}
       >
+        <StyledButton
+          color={COLOR.MIDNIGHT_PURPLE_DEEP}
+          contentColor={COLOR.WHITE}
+          hoverBackgroundColor={COLOR.MIDNIGHT_PURPLE_LIGHT}
+          onClick={() => {
+            handleSave(id)
+          }}
+        >
+          <Icon color={COLOR.WHITE} icon="save" />
+          Save
+        </StyledButton>
         <HeaderContainer>
           <Header>1. Add a title and description</Header>
         </HeaderContainer>
@@ -77,7 +125,14 @@ export default ({ id, hackathons }) => {
             customValue={title}
             onChangeCustomValue={e => setTitle(e.target.value)}
           />
-          <StyledReactQuill theme="snow" modules={descModules} formats={formats} placeholder="Write a description..." />
+          <StyledReactQuill
+            theme="snow"
+            modules={descModules}
+            formats={formats}
+            placeholder="Write a description..."
+            value={content}
+            onChange={setContent}
+          />
         </StyledTextComponent>
       </Page>
     </>

--- a/pages/hackerapps/[id]/welcome.js
+++ b/pages/hackerapps/[id]/welcome.js
@@ -84,10 +84,6 @@ export default ({ id, hackathons }) => {
       setContent(questions[0].content || '')
     }
     fetchQuestions()
-    return () => {
-      setTitle('')
-      setContent('')
-    }
   }, [id])
 
   const handleSave = async hackathon => {

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -746,3 +746,28 @@ export const updateApplicantTags = async (userId, applicantTags) => {
     .doc(userId)
     .update({ applicantTags })
 }
+
+// hacker application questions
+export const getHackerAppQuestions = async (selectedHackathon, category) => {
+  const data = await db.collection('HackerAppQuestions').doc(selectedHackathon.slice(0, -4)).collection(category).get()
+  return data.docs.map(doc => doc.data())
+}
+
+export const updateHackerAppQuestions = async (selectedHackathon, questions, category) => {
+  const hackathonRef = db.collection('HackerAppQuestions').doc(selectedHackathon.slice(0, -4))
+  const categoryRef = hackathonRef.collection(category)
+
+  const batch = db.batch()
+
+  // clear all
+  const existingDocs = await categoryRef.get()
+  existingDocs.forEach(doc => {
+    batch.delete(doc.ref)
+  })
+
+  questions.forEach((question, index) => {
+    const newDocRef = categoryRef.doc(`${index}`)
+    batch.set(newDocRef, question)
+  })
+  await batch.commit()
+}

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -766,7 +766,7 @@ export const updateHackerAppQuestions = async (selectedHackathon, questions, cat
   })
 
   questions.forEach((question, index) => {
-    const newDocRef = categoryRef.doc(`${index}`)
+    const newDocRef = categoryRef.doc(`${index.toString().padStart(3, '0')}`)
     batch.set(newDocRef, question)
   })
   await batch.commit()

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -747,7 +747,7 @@ export const updateApplicantTags = async (userId, applicantTags) => {
     .update({ applicantTags })
 }
 
-// hacker application questions
+// hacker application questions specific
 export const getHackerAppQuestions = async (selectedHackathon, category) => {
   const data = await db.collection('HackerAppQuestions').doc(selectedHackathon.slice(0, -4)).collection(category).get()
   return data.docs.map(doc => doc.data())
@@ -771,3 +771,17 @@ export const updateHackerAppQuestions = async (selectedHackathon, questions, cat
   })
   await batch.commit()
 }
+
+export const getHackerAppQuestionsMetadata = async (selectedHackathon, category) => {
+  const categoryRef = await db.collection('HackerAppQuestions').doc(selectedHackathon.slice(0, -4)).get()
+  return categoryRef.data()[category]
+}
+
+export const updateHackerAppQuestionsMetadata = async (selectedHackathon, category, updatedMetadata) => {
+  const doc = {
+    [category]: updatedMetadata,
+  }
+  return db.collection('HackerAppQuestions').doc(selectedHackathon.slice(0, -4)).set(doc, { merge: true })
+}
+
+// hacker application questions specific end


### PR DESCRIPTION
## Description
Ticket: [https://www.notion.so/nwplus/PA-12-Link-CMS-and-Portal-questions-via-Firebase-a1189899f50a4b8d8d963ea20587bdc2?pvs=4](https://www.notion.so/nwplus/PA-12-Link-CMS-and-Portal-questions-via-Firebase-a1189899f50a4b8d8d963ea20587bdc2?pvs=4)
- moved save btn from page to the subpages
- connected to firebase in 'HackerAppQuestions' collection
- docs within the collection named as 'HackCamp', 'nwHacks', and 'cmd-f' for now since I believe the discussion was to just have the 3 current hackathons on the database and not store previous years' questions 
- loading and saving should work (in dev)
- currently it is clearing and then saving all at the same time per category (e.g. basic info, welcome, skills) bc i think that's how it was in the figma - lmk if you guys think it's better to have a save/delete per question or if that won't be a problem since there'll probably be less than 10 questions per category
