### PR TITLE
Remove Checkbox and File Upload question types, some logic changes

### DIFF
--- a/components/hackerAppNavbar.js
+++ b/components/hackerAppNavbar.js
@@ -11,7 +11,7 @@ const Container = styled.div`
   padding: 12px;
   gap: 20px;
   width: 100px;
-  height: 110px;
+  height: 150px;
   justify-content: center;
 `
 

--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import Toggle from 'react-toggle'
 import TextField from './TextField'
-import { BASIC_INFO_FORM_INPUT_FIELDS, COLOR, QUESTION_TYPES, SKILLS_FORM_INPUT_FIELDS } from '../constants'
+import {
+  BASIC_INFO_FORM_INPUT_FIELDS,
+  COLOR,
+  QUESTION_TYPES,
+  QUESTIONNAIRE_FORM_INPUT_FIELDS,
+  SKILLS_FORM_INPUT_FIELDS,
+} from '../constants'
 import QuestionDropdown from './questionDropdown'
 import Icon from './Icon'
 
@@ -141,6 +147,8 @@ const QuestionCard = ({
       allOptions = BASIC_INFO_FORM_INPUT_FIELDS
     } else if (currentSection === 'skills') {
       allOptions = SKILLS_FORM_INPUT_FIELDS
+    } else if (currentSection === 'questionnaire') {
+      allOptions = QUESTIONNAIRE_FORM_INPUT_FIELDS
     }
     const selectedFormInputs = questions.map(q => q.formInput)
     const filteredOptions = allOptions.filter(
@@ -219,19 +227,19 @@ const QuestionCard = ({
 
       {isToggled && (
         <>
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Question</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Question</QuestionTitle>
           <TextField
             placeholder="Question title"
             customValue={question.title || ''}
             onChangeCustomValue={e => handleChange(id, 'title', e.target.value)}
           />
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Description (optional)</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Description (optional)</QuestionTitle>
           <TextField
             placeholder="Question description"
             customValue={question.description || ''}
             onChangeCustomValue={e => handleChange(id, 'description', e.target.value)}
           />
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Question Type</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Question Type</QuestionTitle>
           <QuestionDropdown
             onSelect={o => handleChange(id, 'type', o)}
             defaultValue={question.type || ''}
@@ -245,7 +253,7 @@ const QuestionCard = ({
             QUESTION_TYPES.LONGANS,
           ].includes(question.type) && (
             <>
-              <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Form Input Field</QuestionTitle>
+              <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Form Input Field</QuestionTitle>
               <QuestionDropdown
                 onSelect={o => handleChange(id, 'formInput', o)}
                 defaultValue={question.formInput || ''}
@@ -258,7 +266,7 @@ const QuestionCard = ({
       )}
       {isToggled && question.type === QUESTION_TYPES.LONGANS && (
         <>
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Max Words</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Max Words</QuestionTitle>
           <TextField
             placeholder="Max words"
             customValue={question.maxWords || ''}
@@ -268,7 +276,7 @@ const QuestionCard = ({
       )}
       {isToggled && [QUESTION_TYPES.MCQ, QUESTION_TYPES.DROPDOWN, QUESTION_TYPES.SELECTALL].includes(question.type) ? (
         <div>
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Options</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Options</QuestionTitle>
           <StyledOptions>
             {(question.options || []).map((option, index) => (
               <OptionsContent key={index}>
@@ -287,7 +295,7 @@ const QuestionCard = ({
             <Icon color={COLOR.MIDNIGHT_PURPLE_DEEP} icon="plus-circle" />
           </StyledQuestionButton>
           <StyledOtherToggle>
-            <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Add Other</QuestionTitle>
+            <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Add Other</QuestionTitle>
             <StyledToggle
               checked={question.other || false}
               icons={false}
@@ -303,7 +311,7 @@ const QuestionCard = ({
             icons={false}
             onChange={() => handleChange(id, 'required', !question.required)}
           />
-          <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Required</QuestionTitle>
+          <QuestionTitle color={COLOR.MIDNIGHT_PURPLE_DEEP}>Required</QuestionTitle>
         </StyledOtherToggle>
       )}
     </StyledQuestionCard>

--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -130,6 +130,7 @@ const QuestionCard = ({
 }) => {
   const [isToggled, setToggled] = useState(true)
   const [formInputOptions, setFormInputOptions] = useState(BASIC_INFO_FORM_INPUT_FIELDS)
+  const [questionTypes, setQuestionTypes] = useState([])
 
   useEffect(() => {
     const pathSegments = window.location.pathname.split('/')
@@ -148,6 +149,32 @@ const QuestionCard = ({
 
     setFormInputOptions(filteredOptions)
   }, [window.location.pathname, questions, question.formInput])
+
+  useEffect(() => {
+    const pathSegments = window.location.pathname.split('/')
+    const currentSection = pathSegments[pathSegments.length - 1]
+
+    let allTypes = [
+      QUESTION_TYPES.MCQ,
+      QUESTION_TYPES.DROPDOWN,
+      QUESTION_TYPES.SELECTALL,
+      QUESTION_TYPES.SHORTANS,
+      QUESTION_TYPES.LONGANS,
+    ]
+    if (currentSection === 'basicinfo') {
+      allTypes = [
+        ...allTypes,
+        QUESTION_TYPES.SCHOOL,
+        QUESTION_TYPES.COUNTRY,
+        QUESTION_TYPES.MAJOR,
+        QUESTION_TYPES.LEGALNAME,
+      ]
+    } else if (currentSection === 'skills') {
+      allTypes = [...allTypes, QUESTION_TYPES.PORTFOLIO]
+    }
+
+    setQuestionTypes(allTypes)
+  }, [window.location.pathname])
 
   const handleOptionChange = (index, value) => {
     const newOptions = [...question.options]
@@ -208,7 +235,7 @@ const QuestionCard = ({
           <QuestionDropdown
             onSelect={o => handleChange(id, 'type', o)}
             defaultValue={question.type || ''}
-            options={Object.values(QUESTION_TYPES)}
+            options={questionTypes}
           />
           {[
             QUESTION_TYPES.MCQ,

--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -210,12 +210,12 @@ const QuestionCard = ({
             defaultValue={question.type || ''}
             options={Object.values(QUESTION_TYPES)}
           />
-          {![
-            QUESTION_TYPES.MAJOR,
-            QUESTION_TYPES.SCHOOL,
-            QUESTION_TYPES.COUNTRY,
-            QUESTION_TYPES.PORTFOLIO,
-            QUESTION_TYPES.LEGALNAME,
+          {[
+            QUESTION_TYPES.MCQ,
+            QUESTION_TYPES.DROPDOWN,
+            QUESTION_TYPES.SELECTALL,
+            QUESTION_TYPES.SHORTANS,
+            QUESTION_TYPES.LONGANS,
           ].includes(question.type) && (
             <>
               <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Form Input Field</QuestionTitle>
@@ -239,10 +239,7 @@ const QuestionCard = ({
           />
         </>
       )}
-      {isToggled &&
-      [QUESTION_TYPES.MCQ, QUESTION_TYPES.DROPDOWN, QUESTION_TYPES.SELECTALL, QUESTION_TYPES.CHECKBOX].includes(
-        question.type
-      ) ? (
+      {isToggled && [QUESTION_TYPES.MCQ, QUESTION_TYPES.DROPDOWN, QUESTION_TYPES.SELECTALL].includes(question.type) ? (
         <div>
           <QuestionTitle color={`${COLOR.MIDNIGHT_PURPLE_DEEP}`}>Options</QuestionTitle>
           <StyledOptions>

--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -132,7 +132,7 @@ const QuestionCard = ({
   const [formInputOptions, setFormInputOptions] = useState(BASIC_INFO_FORM_INPUT_FIELDS)
 
   useEffect(() => {
-    const pathSegments = location.pathname.split('/')
+    const pathSegments = window.location.pathname.split('/')
     const currentSection = pathSegments[pathSegments.length - 1]
 
     let allOptions
@@ -147,7 +147,7 @@ const QuestionCard = ({
     )
 
     setFormInputOptions(filteredOptions)
-  }, [location.pathname, questions, question.formInput])
+  }, [window.location.pathname, questions, question.formInput])
 
   const handleOptionChange = (index, value) => {
     const newOptions = [...question.options]

--- a/constants.js
+++ b/constants.js
@@ -91,6 +91,7 @@ export const HACKER_APP_NAVBAR = {
   welcome: 'Welcome',
   basicinfo: 'Basic Info',
   skills: 'Skills',
+  questionnaire: 'Questionnaire',
 }
 
 export const ASSESSMENT_COLOR = {
@@ -377,3 +378,5 @@ export const SKILLS_FORM_INPUT_FIELDS = [
   'longAnswers4',
   'longAnswers5',
 ]
+
+export const QUESTIONNAIRE_FORM_INPUT_FIELDS = ['eventsAttended', 'engagementSource']

--- a/constants.js
+++ b/constants.js
@@ -341,11 +341,9 @@ export const QUESTION_TYPES = Object.freeze({
   SELECTALL: 'Select All',
   SHORTANS: 'Short Answer',
   LONGANS: 'Long Answer',
-  CHECKBOX: 'Checkbox',
   SCHOOL: 'School',
   COUNTRY: 'Country',
   MAJOR: 'Major',
-  UPLOAD: 'File Upload',
   PORTFOLIO: 'Portfolio',
   LEGALNAME: 'Full Legal Name',
 })

--- a/pages/hackerapps/[id]/questionnaire.js
+++ b/pages/hackerapps/[id]/questionnaire.js
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import {
-  getHackerAppQuestions,
   getHackathonPaths,
   getHackathons,
+  getHackerAppQuestions,
   updateHackerAppQuestions,
   getHackerAppQuestionsMetadata,
   formatDate,
@@ -72,11 +72,11 @@ export default ({ id, hackathons }) => {
 
   useEffect(() => {
     const fetchQuestions = async () => {
-      const appQuestions = await getHackerAppQuestions(id, 'BasicInfo')
+      const appQuestions = await getHackerAppQuestions(id, 'Questionnaire')
       setQuestions(appQuestions)
     }
     const fetchMetadata = async () => {
-      const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'BasicInfo')
+      const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'Questionnaire')
       setMetadata(fetchedMetadata)
     }
     fetchQuestions()
@@ -146,10 +146,10 @@ export default ({ id, hackathons }) => {
       alert('Please make sure that you have selected a formInput field for each question.')
       return
     }
-    await updateHackerAppQuestions(hackathon, questions, 'BasicInfo')
+    await updateHackerAppQuestions(hackathon, questions, 'Questionnaire')
     const newMetadata = { lastEditedAt: getTimestamp(), lastEditedBy: user }
     setMetadata(newMetadata)
-    await updateHackerAppQuestionsMetadata(hackathon, 'BasicInfo', newMetadata)
+    await updateHackerAppQuestionsMetadata(hackathon, 'Questionnaire', newMetadata)
     alert('Questions were saved to the database!')
   }
 
@@ -176,7 +176,7 @@ export default ({ id, hackathons }) => {
           metadata.lastEditedAt?.seconds
         )}`}</StyledMetadataP>
         <HeaderContainer>
-          <Header>2. Add basic information questions</Header>
+          <Header>4. Add questionnaire</Header>
         </HeaderContainer>
         <QuestionsContainer>
           {questions.map((question, index) => (

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -131,7 +131,21 @@ export default ({ id, hackathons }) => {
     setQuestions(newQuestions)
   }
 
+  const validateQuestions = questions => {
+    for (let question of questions) {
+      if (!question.formInput || question.formInput.trim() === '') {
+        return false
+      }
+    }
+    return true
+  }
+
   const handleSave = async hackathon => {
+    const validated = validateQuestions(questions)
+    if (!validated) {
+      alert('Please make sure that you have selected a formInput field for each question.')
+      return
+    }
     await updateHackerAppQuestions(hackathon, questions, 'Skills')
     const newMetadata = { lastEditedAt: getTimestamp(), lastEditedBy: user }
     setMetadata(newMetadata)

--- a/pages/hackerapps/[id]/welcome.js
+++ b/pages/hackerapps/[id]/welcome.js
@@ -106,7 +106,7 @@ export default ({ id, hackathons }) => {
   }, [id])
 
   const handleSave = async hackathon => {
-    const questions = [{ title: title, content: content }]
+    const questions = [{ title, content }]
     await updateHackerAppQuestions(hackathon, questions, 'Welcome')
     const newMetadata = { lastEditedAt: getTimestamp(), lastEditedBy: user }
     setMetadata(newMetadata)


### PR DESCRIPTION
## Description
- remove 'File Upload' and 'Checkbox' question types since checkboxes remain hardcoded in Portal and there is now a 'Portfolio' question type for resume uploads
- changed logic for better UX for the formInput dropdown
- remove ability to select portfolio type for basic info section and ability to select major, school, country, and legal name types in skills section
- added Questionnaire section
- added validation such that users can't save a section when one of the questions doesn't have a formInput field
