### PR TITLE
bring the hacker apps section of the sidebar back

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -208,6 +208,34 @@ export default ({ hackathons, currentPath }) => {
         </NextLink>
 
         <ItemContainer>
+          <Icon color={currentPath && currentPath.includes('hackerapps') && COLOR.WHITE} icon="file-alt" />
+          <Label selected={currentPath && currentPath.includes('hackerapps')}>Hacker Apps</Label>
+        </ItemContainer>
+
+        {HACKATHONS.map(id => {
+          const href = '/hackerapps/[id]/welcome'
+          const link = `/hackerapps/${id}/welcome`
+          return (
+            <NextLink key={id} href={href} as={link} passHref>
+              <IndentedLink
+                onClick={() => {
+                  if (currentPath !== `hackerapps/${id}`) {
+                    setIfTimeOut(
+                      setTimeout(() => {
+                        setLoading(true)
+                      }, 750)
+                    )
+                  }
+                }}
+                selected={currentPath === `hackerapps/${id}`}
+              >
+                {id}
+              </IndentedLink>
+            </NextLink>
+          )
+        })}
+
+        <ItemContainer>
           <Icon icon="th-list" />
           <Label>Hackathons</Label>
         </ItemContainer>


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
the hacker apps section of the sidebar was removed in https://github.com/nwplus/admin/pull/254

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
