### PR TITLE
Add event_type field to Edit Events tab for hackathons

### DIFF
--- a/pages/[id]/events.js
+++ b/pages/[id]/events.js
@@ -27,6 +27,7 @@ import {
   getTimestamp,
   updateEvent,
 } from '../../utility/firebase'
+import Dropdown from '../../components/dropdown'
 
 export default function Events({ id, hackathons }) {
   const [events, setEvents] = useState([])
@@ -121,6 +122,7 @@ export default function Events({ id, hackathons }) {
         <TableData>{props.title}</TableData>
         <TableData>{props.date}</TableData>
         <TableData>{props.points}</TableData>
+        <TableData>{props.type}</TableData>
         <TableData>{props.lastModified}</TableData>
         <TableData actions>
           <ActionsButtonContainer>
@@ -178,6 +180,7 @@ export default function Events({ id, hackathons }) {
                       <TableHeader>Event</TableHeader>
                       <TableHeader>Date</TableHeader>
                       <TableHeader narrow>Points</TableHeader>
+                      <TableHeader>Event Type</TableHeader>
                       <TableHeader>Last Modified</TableHeader>
                       <TableHeader>Actions</TableHeader>
                     </TableRow>
@@ -190,6 +193,7 @@ export default function Events({ id, hackathons }) {
                         title={events[curr].title}
                         text={events[curr].text}
                         points={events[curr].points}
+                        type={events[curr].type}
                         date={events[curr].date}
                         lastModified={events[curr].lastModified}
                         lastModifiedBy={events[curr].lastModifiedBy}
@@ -224,7 +228,7 @@ export default function Events({ id, hackathons }) {
                 }}
               />
             </ModalContent>
-            <ModalContent columns={2}>
+            <ModalContent columns={3}>
               <div>
                 <Label>Date</Label>
                 <DateTimePicker
@@ -232,6 +236,26 @@ export default function Events({ id, hackathons }) {
                   onChange={date => handleInput('date', date, newEvent, setNewEvent)}
                 />
               </div>
+              <ModalField
+                dropdown
+                dropdownOptions={[
+                  {
+                    label: 'main',
+                  },
+                  {
+                    label: 'workshops',
+                  },
+                  {
+                    label: 'minievents',
+                  },
+                ]}
+                label="Type"
+                value={newEvent.type}
+                modalAction={NEW}
+                onChange={type => {
+                  handleInput('type', type.label, newEvent, setNewEvent)
+                }}
+              />
               <ModalField
                 label="Points"
                 modalAction={NEW}
@@ -253,9 +277,10 @@ export default function Events({ id, hackathons }) {
             <ModalContent columns={1}>
               <ModalField label="Description" value={eventViewing.text} modalAction={VIEW} />
             </ModalContent>
-            <ModalContent columns={2}>
+            <ModalContent columns={3}>
               <ModalField label="Date" value={eventViewing.date} modalAction={VIEW} />
               <ModalField label="Points" value={eventViewing.points} modalAction={VIEW} />
+              <ModalField label="Event Type" value={eventViewing.type} modalAction={VIEW} />
             </ModalContent>
           </Modal>
           {/* Modal for editing event */}
@@ -286,7 +311,7 @@ export default function Events({ id, hackathons }) {
                 }}
               />
             </ModalContent>
-            <ModalContent columns={2}>
+            <ModalContent columns={3}>
               <div>
                 <Label>Date</Label>
                 <DateTimePicker
@@ -300,6 +325,26 @@ export default function Events({ id, hackathons }) {
                 modalAction={EDIT}
                 onChange={event => {
                   handleInput('points', event.target.value, eventEditing, setEventEditing)
+                }}
+              />
+              <ModalField
+                dropdown
+                dropdownOptions={[
+                  {
+                    label: 'main',
+                  },
+                  {
+                    label: 'workshops',
+                  },
+                  {
+                    label: 'minievents',
+                  },
+                ]}
+                label="Type"
+                value={eventEditing.type}
+                modalAction={EDIT}
+                onChange={type => {
+                  handleInput('type', type.label, eventEditing, setEventEditing)
                 }}
               />
             </ModalContent>

--- a/pages/[id]/events.js
+++ b/pages/[id]/events.js
@@ -27,7 +27,6 @@ import {
   getTimestamp,
   updateEvent,
 } from '../../utility/firebase'
-import Dropdown from '../../components/dropdown'
 
 export default function Events({ id, hackathons }) {
   const [events, setEvents] = useState([])

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -123,6 +123,7 @@ export const getEvent = (eventID, data) => {
         text: data.text || 'Empty text description for event',
         date: data.date ? formatDate(data.date.seconds) : formatDate(getTimestamp().seconds),
         points: data.points >= 0 ? data.points : '0',
+        type: data.type || 'activities',
         lastModified: data.lastModified ? formatDate(data.lastModified.seconds) : formatDate(getTimestamp().seconds),
         lastModifiedBy: data.lastModifiedBy || 'Unknown user',
       }

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -123,7 +123,7 @@ export const getEvent = (eventID, data) => {
         text: data.text || 'Empty text description for event',
         date: data.date ? formatDate(data.date.seconds) : formatDate(getTimestamp().seconds),
         points: data.points >= 0 ? data.points : '0',
-        type: data.type || 'activities',
+        type: data.type || 'minievents',
         lastModified: data.lastModified ? formatDate(data.lastModified.seconds) : formatDate(getTimestamp().seconds),
         lastModifiedBy: data.lastModifiedBy || 'Unknown user',
       }

--- a/utility/utilities.js
+++ b/utility/utilities.js
@@ -109,6 +109,8 @@ export const filterHackerInfoFields = (obj, collection) => {
     newObj.longAnswers1 = obj.skills?.longAnswers1 || false
     newObj.longAnswers2 = obj.skills?.longAnswers2 || false
     newObj.longAnswers3 = obj.skills?.longAnswers3 || false
+
+    newObj.attendedEvents = obj.dayOf?.events?.map(e => e.eventName).join(', ') ?? ''
   } else if (collection === 'Projects') {
     newObj = { ...obj }
     delete newObj.grades


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
<!--- Describe your changes! Include screenshots/video if applicable -->

Since we will be needing event type (Main Event, Workshop, or Activity) for the Attended Events component in Rewards page of portal, we need to add this field to categorize events.

Also added column for attended events to 'Applicants' section of firebase queries. Since we store attended events per hacker instead of attendees per event, it makes more sense to display it this way.

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->

Event type defaults to displaying as "minievents" in getEvents() - are there any ramifications to this or should I have it display empty if there is no event type