### PR TITLE
Fix empty questions

### DIFF
--- a/components/questionCard.js
+++ b/components/questionCard.js
@@ -191,7 +191,8 @@ const QuestionCard = ({
   }
 
   const addOption = () => {
-    handleChange(id, 'options', [...question.options, ''])
+    const currentOptions = question.options || []
+    handleChange(id, 'options', [...currentOptions, ''])
   }
 
   const removeOption = index => {

--- a/pages/hackerapps/[id]/basicinfo.js
+++ b/pages/hackerapps/[id]/basicinfo.js
@@ -74,7 +74,9 @@ export default ({ id, hackathons }) => {
   useEffect(() => {
     const fetchQuestions = async () => {
       const appQuestions = await getHackerAppQuestions(id, 'BasicInfo')
-      setQuestions(appQuestions)
+      if (appQuestions?.length > 0) {
+        setQuestions(appQuestions)
+      }
     }
     const fetchMetadata = async () => {
       const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'BasicInfo')

--- a/pages/hackerapps/[id]/questionnaire.js
+++ b/pages/hackerapps/[id]/questionnaire.js
@@ -74,7 +74,9 @@ export default ({ id, hackathons }) => {
   useEffect(() => {
     const fetchQuestions = async () => {
       const appQuestions = await getHackerAppQuestions(id, 'Questionnaire')
-      setQuestions(appQuestions)
+      if (appQuestions?.length > 0) {
+        setQuestions(appQuestions)
+      }
     }
     const fetchMetadata = async () => {
       const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'Questionnaire')

--- a/pages/hackerapps/[id]/skills.js
+++ b/pages/hackerapps/[id]/skills.js
@@ -74,7 +74,9 @@ export default ({ id, hackathons }) => {
   useEffect(() => {
     const fetchQuestions = async () => {
       const appQuestions = await getHackerAppQuestions(id, 'Skills')
-      setQuestions(appQuestions)
+      if (appQuestions?.length > 0) {
+        setQuestions(appQuestions)
+      }
     }
     const fetchMetadata = async () => {
       const fetchedMetadata = await getHackerAppQuestionsMetadata(id, 'Skills')


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
When a user deletes the default question on a page and saves the changes to the database, the page will be empty the next time it loads because the empty array fetched from the website will overwrite the default questions. Fixed by only setting the questions array when there are actual stored questions in firebase.

## Other considerations

