### PR TITLE
Modify application scoring to store last updated metadata by question

### DIFF
--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import { useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { APPLICATION_STATUS, COLOR, MAX_SCORE, SCORING, TAGS } from '../../constants'
@@ -34,11 +33,6 @@ const BottomSection = styled.div`
 
 const StyledButton = styled(Button)`
   margin-top: 12px;
-`
-
-const SmallText = styled.div`
-  font-size: 0.8em;
-  color: ${COLOR.GREY_500};
 `
 
 // const Label = styled.p`
@@ -89,15 +83,25 @@ export default function Scoring({ shouldDisplay, applicant }) {
         break
     }
     const newScores = { ...scores }
-    newScores[field] = score
+    newScores[field] = {
+      ...newScores[field],
+      score,
+    }
     newScores.BonusScore = qualifyingBonus()
     setScores(newScores)
     setTotalScore(calculateTotalScore(newScores))
   }
 
   const handleSave = async () => {
-    await updateApplicantScore(applicant._id, scores, comment, user.email)
+    const updatedScores = await updateApplicantScore(
+      applicant._id,
+      scores,
+      applicant?.score?.scores,
+      comment,
+      user.email
+    )
     await updateApplicantStatus(applicant._id, APPLICATION_STATUS.scored.text)
+    setScores(updatedScores)
   }
 
   return (
@@ -155,12 +159,6 @@ export default function Scoring({ shouldDisplay, applicant }) {
       <BottomSection>
         <AddTagButton allTags={TAGS} hacker={applicant} />
         Total Score: {totalScore} / {MAX_SCORE}
-        {applicant && (
-          <SmallText>
-            Last updated by: {applicant?.score?.lastUpdatedBy} at{' '}
-            {moment(applicant?.score?.lastUpdated.toDate()).format('MMM Do, YYYY h:mm:ss A')}
-          </SmallText>
-        )}
         <StyledButton color={COLOR.MIDNIGHT_PURPLE_LIGHT} contentColor={COLOR.WHITE} onClick={handleSave}>
           Save
         </StyledButton>

--- a/components/Evaluator/scoreInput.js
+++ b/components/Evaluator/scoreInput.js
@@ -1,7 +1,8 @@
 // these are the blue buttons for the applicantScore sidebar
 import React from 'react'
 import styled from 'styled-components'
-import { ASSESSMENT_COLOR } from '../../constants'
+import moment from 'moment'
+import { ASSESSMENT_COLOR, COLOR } from '../../constants'
 import Number from './numberIcon'
 
 const Container = styled.div`
@@ -10,12 +11,17 @@ const Container = styled.div`
 
 const ScoreContainer = styled.div`
   display: flex;
-  padding-top: 8px;
+  padding: 8px 0;
   gap: 0.5rem;
 `
 
 const Label = styled.label`
   color: ${ASSESSMENT_COLOR.LIGHT_GRAY};
+`
+
+const SmallText = styled.div`
+  font-size: 0.8em;
+  color: ${COLOR.GREY_500};
 `
 
 export default function ScoreInput({ label, score, handleClick, maxScore, hasMinusOne }) {
@@ -34,13 +40,19 @@ export default function ScoreInput({ label, score, handleClick, maxScore, hasMin
             <Number
               label={label}
               number={num}
-              active={score != null && score / maxScore.weight === num}
+              active={score != null && score.score / maxScore.weight === num}
               key={num}
               handleClick={handleMultipier}
             />
           )
         })}
       </ScoreContainer>
+      {score?.lastUpdated && score?.lastUpdatedBy && (
+        <SmallText>
+          Last updated by: {score?.lastUpdatedBy} at{' '}
+          {moment(score?.lastUpdated.toDate()).format('MMM Do, YYYY h:mm:ss A')}
+        </SmallText>
+      )}
     </Container>
   )
 }

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -20,6 +20,9 @@ if (!firebase.apps.length) {
     messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   }
   firebase.initializeApp(config)
+  firebase.firestore().settings({
+    ignoreUndefinedProperties: true,
+  })
 }
 
 export const db = firebase.firestore()
@@ -781,21 +784,33 @@ export const getAllResumes = async () => {
   download(finishedZip, 'Resumes', 'application/zip')
 }
 
-export const updateApplicantScore = async (applicantID, scores, comment, adminEmail) => {
-  const totalScore = scores ? calculateTotalScore(scores) : null
+export const updateApplicantScore = async (applicantID, newScores, oldScores, comment, adminEmail) => {
+  const totalScore = newScores ? calculateTotalScore(newScores) : null
+  const scoresWithUpdatedTimes = Object.entries(newScores).reduce((prev, [question, scoreObj]) => {
+    const scoreChanged = oldScores[question]?.score !== scoreObj.score
+    return {
+      ...prev,
+      [question]: {
+        ...scoreObj,
+        lastUpdated: scoreChanged ? getTimestamp() : oldScores[question].lastUpdated,
+        lastUpdatedBy: scoreChanged ? adminEmail : oldScores[question].lastUpdatedBy,
+      },
+    }
+  }, {})
+
   db.collection('Hackathons')
     .doc(HackerEvaluationHackathon)
     .collection('Applicants')
     .doc(applicantID)
     .update({
       score: {
-        scores,
+        scores: scoresWithUpdatedTimes,
         totalScore,
         comment,
-        lastUpdated: firebase.firestore.Timestamp.now(),
-        lastUpdatedBy: adminEmail,
       },
     })
+
+  return scoresWithUpdatedTimes
 }
 
 export const updateApplicantStatus = async (userId, applicationStatus, hackathon) => {

--- a/utility/utilities.js
+++ b/utility/utilities.js
@@ -13,7 +13,12 @@ export const calculateTotalScore = hackerScore => {
   // summing up values score
   const reducer = (accumulator, currentValue) => accumulator + currentValue
   const maxScore = Object.values(SCORING).reduce((acc, curr) => acc + curr.value * curr.weight, 0)
-  return Math.min(maxScore, Object.values(hackerScore).reduce(reducer, 0))
+  return Math.min(
+    maxScore,
+    Object.values(hackerScore)
+      .map(score => score?.score ?? 0)
+      .reduce(reducer, 0)
+  )
 }
 
 // Given an object, flatten all key/values, taking all nested properties to top level


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
<!--- Describe your changes! Include screenshots/video if applicable -->

New schema for storing scores:

![image](https://github.com/user-attachments/assets/87658aa1-b863-4854-bf4f-26a48795e77d)

Instead of each app question being mapped directly to a score, it is mapped to an object containing store + last updated metadata

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->

This change definitely breaks the /assessment endpoint since it modifies an underlying function used by both, but considering the page looks broken already, we should be fine :)

This PR also modifies a global firebase setting - setting/updating now ignores undefined values where previously it would error.