### PR TITLE
Normalization UI

### DIFF
--- a/components/Assessment/Modal.js
+++ b/components/Assessment/Modal.js
@@ -25,7 +25,7 @@ const ModalDiv = styled.div`
   align-items: center;
 `
 
-export default function Modal({ children, setShowing }) {
+export default function Modal({ children, setShowing, className }) {
   const backgroundRef = useRef()
   useEffect(() => {
     const escFunction = ({ keyCode }) => {
@@ -47,7 +47,7 @@ export default function Modal({ children, setShowing }) {
         }
       }}
     >
-      <ModalDiv>{children}</ModalDiv>
+      <ModalDiv className={className}>{children}</ModalDiv>
     </GreyDiv>
   )
 }

--- a/components/Assessment/Modal.js
+++ b/components/Assessment/Modal.js
@@ -5,7 +5,9 @@ const GreyDiv = styled.div`
   height: 100vh;
   width: 100vw;
   background: rgba(0, 0, 0, 0.4);
-  position: absolute;
+  top: 0;
+  left: 0;
+  position: fixed;
   z-index: 99;
 `
 
@@ -13,7 +15,7 @@ const ModalDiv = styled.div`
   width: 400px;
   height: 70%;
   overflow-y: auto;
-  position: absolute;
+  position: fixed;
   left: 50%;
   top: 25%;
   background-color: white;

--- a/components/Assessment/acceptingModal.js
+++ b/components/Assessment/acceptingModal.js
@@ -69,6 +69,7 @@ const acceptApplicant = async applicant => {
 export default function AcceptingModal({ setShowing }) {
   const [totalApplicants, setTotalApplicants] = useState(0)
   const [score, setScore] = useState(undefined)
+  const [zscore, setZScore] = useState(undefined)
   const [numHackathonsMin, setNumHackathonsMin] = useState(undefined)
   const [numHackathonsMax, setNumHackathonsMax] = useState(undefined)
   const [yearLevelOptions, setYearLevelOptions] = useState([])
@@ -82,6 +83,7 @@ export default function AcceptingModal({ setShowing }) {
   const getApplicants = async () => {
     const apps = await getApplicantsToAccept(
       score,
+      zscore,
       numHackathonsMin,
       numHackathonsMax,
       yearLevelsSelected,
@@ -137,6 +139,15 @@ export default function AcceptingModal({ setShowing }) {
           }}
           value={score ?? ''}
           placeholder="minimum score"
+        />
+        <TotalApplicantsP>Minimum z-score</TotalApplicantsP>
+        <ScoreInput
+          onChange={e => {
+            // eslint-disable-next-line no-restricted-globals
+            if (!isNaN(e.target.value)) setZScore(e.target.value)
+          }}
+          value={zscore ?? ''}
+          placeholder="minimum z-score"
         />
         <TotalApplicantsP>Number of Hackathons Attended</TotalApplicantsP>
         <RangeContainer>

--- a/components/Evaluator/CalcZScoreButton.js
+++ b/components/Evaluator/CalcZScoreButton.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import styled from 'styled-components'
+import { COLOR } from '../../constants'
+import Button from '../button'
+
+const StyledButton = styled(Button)`
+  background: ${COLOR.MIDNIGHT_PURPLE_LIGHT};
+  color: white;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+`
+
+export default function CalcZScoreButton() {
+  return <StyledButton>Calculate z-score</StyledButton>
+}

--- a/components/Evaluator/CalcZScoreButton.js
+++ b/components/Evaluator/CalcZScoreButton.js
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { COLOR } from '../../constants'
 import Button from '../button'
+import Modal from '../Assessment/Modal'
 
 const StyledButton = styled(Button)`
   background: ${COLOR.MIDNIGHT_PURPLE_LIGHT};
@@ -11,6 +12,65 @@ const StyledButton = styled(Button)`
   align-items: center;
 `
 
+const StyledModal = styled(Modal)`
+  height: auto !important;
+  border-radius: 10px;
+`
+const ModalContent = styled.div`
+  padding: 20px;
+  text-align: center;
+`
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+`
+
+const ModalButton = styled(Button)`
+  margin: 10px;
+  background: ${props => (props.variant === 'no' ? COLOR.RED : COLOR.GREEN)};
+  color: white;
+`
+
 export default function CalcZScoreButton() {
-  return <StyledButton>Calculate z-score</StyledButton>
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const handleButtonClick = () => {
+    setIsModalOpen(true)
+  }
+
+  const handleYesClick = () => {
+    // TODO: logic to calculate z-score goes in here?
+    setIsModalOpen(false)
+  }
+
+  const handleNoClick = () => {
+    setIsModalOpen(false)
+  }
+  return (
+    <>
+      <StyledButton onClick={handleButtonClick}>Calculate z-score</StyledButton>
+      {isModalOpen && (
+        <StyledModal setShowing={setIsModalOpen}>
+          <ModalContent>
+            <p>
+              🚨<strong>You are about to run a big script!</strong>
+            </p>
+            <p>
+              Are you sure you want to calculate all z-scores? Please verify that{' '}
+              <strong>all grading has been completed.</strong>
+            </p>
+            <ButtonContainer>
+              <ModalButton variant="no" onClick={handleNoClick}>
+                No
+              </ModalButton>
+              <ModalButton variant="yes" onClick={handleYesClick}>
+                Yes
+              </ModalButton>
+            </ButtonContainer>
+          </ModalContent>
+        </StyledModal>
+      )}
+    </>
+  )
 }

--- a/components/Evaluator/HackerEntry.js
+++ b/components/Evaluator/HackerEntry.js
@@ -59,6 +59,8 @@ const StyledTag = styled.div`
       ? `background: ${ASSESSMENT_COLOR.YELLOW};`
       : p.status === APPLICATION_STATUS.scored.text
       ? `background: ${ASSESSMENT_COLOR.BLUE};`
+      : p.status === APPLICATION_STATUS.gradinginprog.text
+      ? `background: ${ASSESSMENT_COLOR.DARK_GRAY};`
       : `background: ${ASSESSMENT_COLOR.RED};`}
   padding: 0px 5px;
   border-radius: 4px;
@@ -93,8 +95,11 @@ export default function HackerEntry({
         return <StyledTag status={status}>{APPLICATION_STATUS.waitlisted.displayText}</StyledTag>
       case APPLICATION_STATUS.rejected.text:
         return <StyledTag status={status}>{APPLICATION_STATUS.rejected.displayText}</StyledTag>
+      case APPLICATION_STATUS.gradinginprog.text:
+        return <StyledTag status={status}>{APPLICATION_STATUS.gradinginprog.displayText}</StyledTag>
+      case APPLICATION_STATUS.ungraded.text:
       default:
-        return <StyledTag status={status}>Ungraded</StyledTag>
+        return <StyledTag status={status}>{APPLICATION_STATUS.ungraded.displayText}</StyledTag>
     }
   }
 
@@ -107,7 +112,7 @@ export default function HackerEntry({
           Applicant {index}
         </HackerName>
         <HackerInfoText>
-          Score: {score?.totalScore ?? '?'}/{MAX_SCORE}
+          Score: {score?.totalScore !== undefined ? `${score.totalScore}/${MAX_SCORE}` : 'n/a'}
         </HackerInfoText>
       </StyledInfoContainer>
       {getStyleTag()}

--- a/components/Evaluator/HackerEntry.js
+++ b/components/Evaluator/HackerEntry.js
@@ -70,6 +70,11 @@ const StyledTag = styled.div`
   justify-content: center;
 `
 
+const ScoreContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`
+
 export default function HackerEntry({
   index,
   // firstName,
@@ -103,6 +108,24 @@ export default function HackerEntry({
     }
   }
 
+  const getTotalZScore = () => {
+    const { NumExperiences, ResponseOneScore, ResponseTwoScore, ResponseThreeScore } = score?.scores || {}
+    if (
+      NumExperiences?.normalizedScore !== undefined &&
+      ResponseOneScore?.normalizedScore !== undefined &&
+      ResponseTwoScore?.normalizedScore !== undefined &&
+      ResponseThreeScore?.normalizedScore !== undefined
+    ) {
+      return (
+        NumExperiences.normalizedScore +
+        ResponseOneScore.normalizedScore +
+        ResponseTwoScore.normalizedScore +
+        ResponseThreeScore.normalizedScore
+      )
+    }
+    return undefined
+  }
+
   return (
     <StyledHackerEntryDiv onClick={() => selectHacker(id)} selected={isSelected}>
       <HackerIndex>{index}</HackerIndex>
@@ -111,9 +134,14 @@ export default function HackerEntry({
           {/* {firstName} {lastName} */}
           Applicant {index}
         </HackerName>
-        <HackerInfoText>
-          Score: {score?.totalScore !== undefined ? `${score.totalScore}/${MAX_SCORE}` : 'n/a'}
-        </HackerInfoText>
+        <ScoreContainer>
+          <HackerInfoText>
+            Score: {score?.totalScore !== undefined ? `${score.totalScore}/${MAX_SCORE}` : 'n/a'}
+          </HackerInfoText>
+          <HackerInfoText>
+            {getTotalZScore() !== undefined && <strong>z: {getTotalZScore().toFixed(2)}</strong>}
+          </HackerInfoText>
+        </ScoreContainer>
       </StyledInfoContainer>
       {getStyleTag()}
     </StyledHackerEntryDiv>

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -87,6 +87,17 @@ export default function Scoring({ shouldDisplay, applicant }) {
     //   : 0;
   }
 
+  const updateScore = (field, score) => {
+    const newScores = { ...scores }
+    newScores[field] = {
+      ...newScores[field],
+      score,
+    }
+    newScores.BonusScore = qualifyingBonus()
+    setScores(newScores)
+    setTotalScore(calculateTotalScore(newScores))
+  }
+
   // TODO: For next hackathon, change to camelCase.
   const handleClick = (score, label) => {
     // Switch to whatever the field is in Firebase
@@ -118,17 +129,6 @@ export default function Scoring({ shouldDisplay, applicant }) {
     } else {
       updateScore(field, score)
     }
-  }
-
-  const updateScore = (field, score) => {
-    const newScores = { ...scores }
-    newScores[field] = {
-      ...newScores[field],
-      score,
-    }
-    newScores.BonusScore = qualifyingBonus()
-    setScores(newScores)
-    setTotalScore(calculateTotalScore(newScores))
   }
 
   const handleYesClick = () => {

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -257,7 +257,7 @@ export default function Scoring({ shouldDisplay, applicant }) {
       <BottomSection>
         <AddTagButton allTags={TAGS} hacker={applicant} />
         Total Score: {totalScore} / {MAX_SCORE}
-        <br></br>
+        <br />
         {getTotalZScore() !== undefined && <strong>Total Z-score: {getTotalZScore()}</strong>}
         <StyledButton color={COLOR.MIDNIGHT_PURPLE_LIGHT} contentColor={COLOR.WHITE} onClick={handleSave}>
           Save

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -110,7 +110,8 @@ export default function Scoring({ shouldDisplay, applicant }) {
 
     if (filledFields.length === 0) {
       return APPLICATION_STATUS.ungraded.text
-    } else if (filledFields.length < requiredFields.length) {
+    }
+    if (filledFields.length < requiredFields.length) {
       return APPLICATION_STATUS.gradinginprog.text
     }
     return APPLICATION_STATUS.scored.text

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -178,6 +178,24 @@ export default function Scoring({ shouldDisplay, applicant }) {
     setScores(updatedScores)
   }
 
+  const getTotalZScore = () => {
+    const { NumExperiences, ResponseOneScore, ResponseTwoScore, ResponseThreeScore } = scores || {}
+    if (
+      NumExperiences?.normalizedScore !== undefined &&
+      ResponseOneScore?.normalizedScore !== undefined &&
+      ResponseTwoScore?.normalizedScore !== undefined &&
+      ResponseThreeScore?.normalizedScore !== undefined
+    ) {
+      return (
+        NumExperiences.normalizedScore +
+        ResponseOneScore.normalizedScore +
+        ResponseTwoScore.normalizedScore +
+        ResponseThreeScore.normalizedScore
+      ).toFixed(2)
+    }
+    return undefined
+  }
+
   return (
     <Container shouldDisplay={shouldDisplay}>
       <Title5 color={COLOR.MIDNIGHT_PURPLE}>Scoring</Title5>
@@ -239,6 +257,8 @@ export default function Scoring({ shouldDisplay, applicant }) {
       <BottomSection>
         <AddTagButton allTags={TAGS} hacker={applicant} />
         Total Score: {totalScore} / {MAX_SCORE}
+        <br></br>
+        {getTotalZScore() !== undefined && <strong>Total Z-score: {getTotalZScore()}</strong>}
         <StyledButton color={COLOR.MIDNIGHT_PURPLE_LIGHT} contentColor={COLOR.WHITE} onClick={handleSave}>
           Save
         </StyledButton>

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -95,6 +95,28 @@ export default function Scoring({ shouldDisplay, applicant }) {
     setTotalScore(calculateTotalScore(newScores))
   }
 
+  // if none of the required fields are in scores or if scores doesnt even exist, set APPLICATION_STATUS.ungraded.text
+  // if one of the reuiqred fields are in scores and not all, set APPLICATION_STATUS.gradinginprog.text
+  // if all required fields are in, set APPLICATION_STATUS.scored.text
+  const getStatus = scores => {
+    // TODO: UPDATE REQUIRED FIELDS PER HACKATHON
+    const requiredFields = ['ResumeScore', 'ResponseOneScore', 'ResponseTwoScore', 'ResponseThreeScore']
+
+    if (!scores) {
+      return APPLICATION_STATUS.ungraded.text
+    }
+
+    const filledFields = requiredFields.filter(field => scores[field] !== null && scores[field] !== undefined)
+
+    if (filledFields.length === 0) {
+      return APPLICATION_STATUS.ungraded.text
+    } else if (filledFields.length < requiredFields.length) {
+      return APPLICATION_STATUS.gradinginprog.text
+    } else {
+      return APPLICATION_STATUS.scored.text
+    }
+  }
+
   const handleSave = async () => {
     const updatedScores = await updateApplicantScore(
       applicant._id,
@@ -103,7 +125,9 @@ export default function Scoring({ shouldDisplay, applicant }) {
       comment,
       user.email
     )
-    await updateApplicantStatus(applicant._id, APPLICATION_STATUS.scored.text)
+    // checks if all fields have scores and update accordingly
+    const newStatus = getStatus(updatedScores)
+    await updateApplicantStatus(applicant._id, newStatus)
     setScores(updatedScores)
   }
 

--- a/components/Evaluator/Scoring.js
+++ b/components/Evaluator/Scoring.js
@@ -98,7 +98,7 @@ export default function Scoring({ shouldDisplay, applicant }) {
   // if none of the required fields are in scores or if scores doesnt even exist, set APPLICATION_STATUS.ungraded.text
   // if one of the reuiqred fields are in scores and not all, set APPLICATION_STATUS.gradinginprog.text
   // if all required fields are in, set APPLICATION_STATUS.scored.text
-  const getStatus = scores => {
+  const getStatus = () => {
     // TODO: UPDATE REQUIRED FIELDS PER HACKATHON
     const requiredFields = ['ResumeScore', 'ResponseOneScore', 'ResponseTwoScore', 'ResponseThreeScore']
 
@@ -112,9 +112,8 @@ export default function Scoring({ shouldDisplay, applicant }) {
       return APPLICATION_STATUS.ungraded.text
     } else if (filledFields.length < requiredFields.length) {
       return APPLICATION_STATUS.gradinginprog.text
-    } else {
-      return APPLICATION_STATUS.scored.text
     }
+    return APPLICATION_STATUS.scored.text
   }
 
   const handleSave = async () => {

--- a/constants.js
+++ b/constants.js
@@ -134,6 +134,18 @@ export const APPLICATION_STATUS = {
     text: 'rejected',
     displayText: 'Rejected',
   },
+  gradinginprog: {
+    color: ASSESSMENT_COLOR.DARK_GRAY,
+    textColor: 'white',
+    text: 'gradinginprog',
+    displayText: 'In progress',
+  },
+  ungraded: {
+    color: ASSESSMENT_COLOR.RED,
+    textColor: 'white',
+    text: 'ungraded',
+    displayText: 'Ungraded',
+  },
   scored: {
     color: ASSESSMENT_COLOR.BLUE,
     textColor: 'white',

--- a/pages/eval.js
+++ b/pages/eval.js
@@ -6,6 +6,7 @@ import Rubric from '../components/Evaluator/Rubric'
 import Scoring from '../components/Evaluator/Scoring'
 import Page from '../components/page'
 import { getAllApplicants, getHackathons } from '../utility/firebase'
+import CalcZScoreButton from '../components/Evaluator/CalcZScoreButton'
 
 const Container = styled.div`
   display: grid;
@@ -45,7 +46,8 @@ export default function Eval({ hackathons }) {
   return (
     <Page hackathons={hackathons} currentPath="eval" isFullscreen>
       <Container>
-        <Column items={2}>
+        <Column items={3}>
+          <CalcZScoreButton />
           <HackerList
             applicants={applicants}
             selectedApplicant={selectedApplicant}

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -675,7 +675,7 @@ export const getApplicantsToAccept = async (
         ResponseOneScore?.normalizedScore,
         ResponseTwoScore?.normalizedScore,
         ResponseThreeScore?.normalizedScore,
-      ].reduce((acc, score) => acc + (score !== undefined ? score : 0), 0)
+      ].reduce((acc, normalizedScore) => acc + (normalizedScore !== undefined ? normalizedScore : 0), 0)
 
       if (zscore !== undefined && totalZScore < zscore) return false
 

--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -648,6 +648,7 @@ export const getAllApplicants = async callback => {
 
 export const getApplicantsToAccept = async (
   score,
+  zscore,
   numHackathonsMin,
   numHackathonsMax,
   yearLevelsSelected,
@@ -666,6 +667,17 @@ export const getApplicantsToAccept = async (
 
       // score
       if (score !== undefined && appData.score.totalScore < score) return false
+
+      // zscore
+      const { NumExperiences, ResponseOneScore, ResponseTwoScore, ResponseThreeScore } = appData.score.scores || {}
+      const totalZScore = [
+        NumExperiences?.normalizedScore,
+        ResponseOneScore?.normalizedScore,
+        ResponseTwoScore?.normalizedScore,
+        ResponseThreeScore?.normalizedScore,
+      ].reduce((acc, score) => acc + (score !== undefined ? score : 0), 0)
+
+      if (zscore !== undefined && totalZScore < zscore) return false
 
       // range of hackathons attended
       const numHackathonsAttended = appData.skills?.numHackathonsAttended


### PR DESCRIPTION
## Description
Ticket: [https://www.notion.so/nwplus/normalization-Add-new-UI-components-14c14d529faa8018b591e555d9d81480?pvs=4](https://www.notion.so/nwplus/normalization-Add-new-UI-components-14c14d529faa8018b591e555d9d81480?pvs=4)
- added component `CalcZScoreButton`; the normalization function isn't in here anywhere yet 
- added the ff new `APPLICANT_STATUSES`: `gradinginprog`, `ungraded`, and `scored`:
  - `scored`: if all required fields to score exist and have a value
  - `gradinginprog`: if one or more fields exist and have a value but not all
  - `ungraded`: if none of the fields exist/`score` doesn't exist
- made bg color of `gradinginprog` gray as specified by figma file
- added verification modal when calculating z-scores
- added verification modal when changing a score for a question that was previously graded by someone else
- display prev total z-score on completely graded apps (i think this would only get updated when the big calczscorebutton is clicked again?) on `HackerEntry` and `Scoring` components
- added total z-score filter for acceptances