### PR TITLE
Sum up points for each hacker's event attendance in firebase queries

### DIFF
--- a/utility/firebase.js
+++ b/utility/firebase.js
@@ -592,11 +592,10 @@ export const getHackerInfo = async (callback, hackathon, collection) => {
     .doc(hackathon)
     .collection(collection)
     .onSnapshot(snap => {
-      callback(
-        snap.docs.map(doc => {
-          return orderObj(flattenObj(filterHackerInfoFields(doc.data(), collection)))
-        })
-      )
+      const hackerInfoPromises = snap.docs.map(async doc => {
+        return orderObj(flattenObj(await filterHackerInfoFields(db, doc.data(), hackathon, collection)))
+      })
+      Promise.all(hackerInfoPromises).then(callback)
     })
   return res
 }


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
<!--- Describe your changes! Include screenshots/video if applicable -->

Added a column in firebase queries section for letting admins see total points of each hacker based on dayOf event attendance.

![image](https://github.com/user-attachments/assets/72a1a91e-883f-41ca-bc47-ba5dc049d4c1)


## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->

Pretty ugly solution :/ to get each event's points we have to separately get the doc for it and since all the column setting logic occurs in the filterHackerInfoFields function I just put the fetching stuff in there which is not very single responsibility of me ;-;